### PR TITLE
fix munmap error by rewinding pointer to original position

### DIFF
--- a/MemoryMapping/MemoryMappedFile.tpp
+++ b/MemoryMapping/MemoryMappedFile.tpp
@@ -160,6 +160,7 @@ namespace mm
 	template<CacheHint ch, MapMode mpm>
 	void MemoryMappedFile<ch, mpm>::Close()
 	{
+	        Rewind();
 		// kill pointer
 		if (_mappedView)
 		{
@@ -219,6 +220,7 @@ namespace mm
 		// close old mapping
 		if (_mappedView)
 		{
+		        Rewind();
 #ifdef _MSC_VER
 			::UnmapViewOfFile(_mappedView);
 #else


### PR DESCRIPTION
After advancing internal pointer during reading of npy file, subsequent call to munmap fails.